### PR TITLE
Add a missing CNTR_CTRM to _SetCNTR

### DIFF
--- a/bootloader/usb.c
+++ b/bootloader/usb.c
@@ -183,7 +183,7 @@ void USB_Init(void (*EPHandlerPtr)(uint16_t), void (*ResetHandlerPtr)(void)) {
 	_SetISTR(0);
 
 	/*** Set interrupt mask ***/
-	_SetCNTR(CNTR_RESETM | CNTR_SUSPM | CNTR_WKUPM);
+	_SetCNTR(CNTR_CTRM | CNTR_RESETM | CNTR_SUSPM | CNTR_WKUPM);
 }
 
 uint16_t USB_IsDeviceConfigured() {


### PR DESCRIPTION
The final call to _SetCNTR was missing CNTR_CTRM bit. Somehow it is not a problem for genuine STM32 parts, however it causes GD32 clones (software/pin compatible, mostly) to fail to enumerate. Adding the missing mask bit solves the issue and STM32 parts still work fine.